### PR TITLE
 test: verify that you can pass a JSON file with config

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ module.exports = (on, config) => {
 
 ## Konfiguration
 
-Konfigurationen av plugin:et görs i `@forsakringskassan/cypress-axe.json` i root-katalogen.
+Konfigurationen av plugin:et görs i `fk-cypress-axe.json` i root-katalogen.
 
 Basinställningarna ser ut som följande:
 
@@ -90,7 +90,7 @@ Basinställningarna ser ut som följande:
 }
 ```
 
-Genom att fylla i en lokal `@forsakringskassan/cypress-axe.json` kan man alltså skriva över enskilda inställningar i denna filen.
+Genom att fylla i en lokal `fk-cypress-axe.json` kan man alltså skriva över enskilda inställningar i denna filen.
 Resterande fält diff:as mot basinställningarna.
 
 **OBS:** Vissa inställningar diff:as ej, nämligen inställningarna som finns i `axe.rules`.
@@ -101,7 +101,7 @@ Dvs. om man i sin lokala konfiguration ändrar `'color-contrast'` regeln på nå
 Utöver `excludeSelectorsList` kan man använda `context` för att ange vad som ska inkluderas och exkluderas.
 Detta påverkar vilka element som axe kör på iställer för filtrering i efterhand.
 
-`@forsakringskassan/cypress-axe.json`:
+`fk-cypress-axe.json`:
 
 ```json
 {

--- a/cypress/e2e/invalid-block.cy.ts
+++ b/cypress/e2e/invalid-block.cy.ts
@@ -1,0 +1,5 @@
+describe("Invalid Block Accessibility", () => {
+    it("fails if config includes invalid blocks", () => {
+        cy.visit("/invalid-block.html");
+    });
+});

--- a/src/test.spec.ts
+++ b/src/test.spec.ts
@@ -1,13 +1,32 @@
+import fs from "node:fs/promises";
 import cypress from "cypress";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const TMP_DIR = "./temp/cypress-e2e";
+const DEFAULT_CYPRESS_TIMEOUT = 60000;
+
+vi.setConfig({ testTimeout: DEFAULT_CYPRESS_TIMEOUT });
+
+beforeEach(async () => {
+    await fs.mkdir(TMP_DIR, { recursive: true });
+
+    await fs.copyFile("cypress.config.ts", `${TMP_DIR}/cypress.config.ts`);
+    await fs.cp("cypress", `${TMP_DIR}/cypress`, { recursive: true });
+});
+
+afterEach(async () => {
+    await fs.rm(TMP_DIR, { recursive: true, force: true });
+});
 
 async function runCypressSpec(
     specFile: string,
 ): Promise<CypressCommandLine.CypressRunResult> {
     const result = await cypress.run({
-        spec: specFile,
+        spec: `**/*/${specFile}`,
         headless: true,
+        project: TMP_DIR,
     });
+
     if ("status" in result) {
         throw new Error(`Cypress failed to start: ${result.message}`);
     }
@@ -19,11 +38,45 @@ describe("Cypress E2E Tester via Vitest", () => {
         const result = await runCypressSpec("cypress/e2e/valid-page.cy.ts");
         expect(result.totalFailed).toBe(0);
         expect(result.totalTests).toBeGreaterThan(0);
-    }, 60000);
+    });
 
     it("should fail the tests in invalidPage.spec.ts", async () => {
         const result = await runCypressSpec("cypress/e2e/invalid-page.cy.ts");
         expect(result.totalFailed).toBe(1);
         expect(result.totalTests).toBeGreaterThan(0);
-    }, 60000);
+    });
+});
+
+describe("Configuration with JSON file", () => {
+    it("should pass since we only check a valid block", async () => {
+        const fkAxeJson = {
+            context: {
+                include: [[".valid-block"]],
+            },
+        };
+
+        await fs.writeFile(
+            `${TMP_DIR}/fk-cypress-axe.json`,
+            JSON.stringify(fkAxeJson, null, 2),
+        );
+
+        const result = await runCypressSpec("cypress/e2e/invalid-block.cy.ts");
+        expect(result.totalFailed).toBe(0);
+    });
+
+    it("should fail since we check a invalid block", async () => {
+        const fkAxeJson = {
+            context: {
+                include: [[".invalid-block"]],
+            },
+        };
+
+        await fs.writeFile(
+            `${TMP_DIR}/fk-cypress-axe.json`,
+            JSON.stringify(fkAxeJson, null, 2),
+        );
+
+        const result = await runCypressSpec("cypress/e2e/invalid-block.cy.ts");
+        expect(result.totalFailed).toBe(1);
+    });
 });

--- a/test-server/pages/invalid-block.html
+++ b/test-server/pages/invalid-block.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <title>One Section with invalid code, and one valid section</title>
+    </head>
+    <body>
+        <div class="valid-block">
+            <button type="button">A button that does nothing</button>
+        </div>
+        <div class="invalid-block">
+            <div style="padding: 20px; font-family: sans-serif">
+                <h1 style="color: #fff; background-color: #fff">Text with contrast issue</h1>
+
+                Enter your number: <input type="number" id="name" />
+            </div>
+        </div>
+    </body>
+</html>


### PR DESCRIPTION
Har ändrat upplägget att Vite tar och kopierar över alla Cypress-relaterade filer i `temp/` för att kunna modifiera innehåll innan själva Cypress startas.


Har lite tankar på att optimera testerna (tar ca ~20sek att köra alla just nu) men tänker ta det som egna PR's. Just nu öppnar varje test upp sin egna Cypress.

Att verifiera att du kan läsa in fk-cypress-axe.json är en förutsättning för att jag skall kunna modifiera existerande kod utan att ta sönder nåt.

Råkade i tidgare PR ta sönder readme med en find/replace, filnamnet skall vara `fk-cypress-axe.json` och inget annat.