### PR TITLE
feat: pass config from your cypress configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,9 +62,45 @@ module.exports = (on, config) => {
 
 ## Konfiguration
 
-Konfigurationen av plugin:et görs i `fk-cypress-axe.json` i root-katalogen.
+Konfiguration kan antingen skickas in vid init i `cypress.config.ts` eller via separat JSON-fil.
 
-Basinställningarna ser ut som följande:
+`cypress.config.ts`
+
+```ts
+import { defineConfig } from "cypress";
+import { init as installAxe } from "@forsakringskassan/cypress-axe/plugins";
+
+const axeOptions = {
+    "context": {
+        "include": [["#app"]],
+        "exclude": [[".selector1"], [".selector2"], ["..."]]
+    }
+}
+
+export default defineConfig({
+    allowCypressEnv: true,
+
+    e2e: {
+        ...
+        setupNodeEvents(on, config) {
+            return installAxe(on, config, axeOptions);
+        },
+    },
+});
+```
+
+`fk-cypress-axe.json`
+
+```json
+{
+    "context": {
+        "include": [["#app"]],
+        "exclude": [[".selector1"], [".selector2"], ["..."]]
+    }
+}
+```
+
+## Basinställning
 
 ```javascript
 {
@@ -100,8 +136,6 @@ Dvs. om man i sin lokala konfiguration ändrar `'color-contrast'` regeln på nå
 
 Utöver `excludeSelectorsList` kan man använda `context` för att ange vad som ska inkluderas och exkluderas.
 Detta påverkar vilka element som axe kör på iställer för filtrering i efterhand.
-
-`fk-cypress-axe.json`:
 
 ```json
 {

--- a/src/plugins.js
+++ b/src/plugins.js
@@ -20,14 +20,20 @@ const tasks = {
 /**
  * @template T
  * @param {T} config
+ * @param {any} userOptions
  * @returns {T}
  */
-export function init(on, config) {
+export function init(on, config, userOptions = undefined) {
     // Registers plugin-specific task events
     on("task", tasks);
 
     // Load plugin configuration
     // [Workaround] Cannot store deep structures in config object => Store entire json file as environment variable
+    if (userOptions !== undefined) {
+        config.env[envName] = JSON.stringify(userOptions);
+        return config;
+    }
+
     try {
         const localConfig = fs.readFileSync("fk-cypress-axe.json").toString();
         config.env[envName] = localConfig;

--- a/src/test.spec.ts
+++ b/src/test.spec.ts
@@ -18,6 +18,34 @@ afterEach(async () => {
     await fs.rm(TMP_DIR, { recursive: true, force: true });
 });
 
+async function generateCypressConfig(
+    fkAxeJson: Record<string, unknown>,
+): Promise<void> {
+    const cypressConfigFile = `
+
+import { defineConfig } from "cypress";
+import { init as installAxe } from "@forsakringskassan/cypress-axe/plugins";
+
+const PORT: number = Number.parseInt(
+    process.env.FK_AXE_SERVER_PORT ?? "8080",
+    10,
+);
+
+export default defineConfig({
+    allowCypressEnv: true,
+
+    e2e: {
+        baseUrl: \`http://localhost:\${PORT}\`,
+        setupNodeEvents(on, config) {
+            return installAxe(on, config, ${JSON.stringify(fkAxeJson)});
+        },
+    },
+});
+        `;
+
+    await fs.writeFile(`${TMP_DIR}/cypress.config.ts`, cypressConfigFile);
+}
+
 async function runCypressSpec(
     specFile: string,
 ): Promise<CypressCommandLine.CypressRunResult> {
@@ -75,6 +103,34 @@ describe("Configuration with JSON file", () => {
             `${TMP_DIR}/fk-cypress-axe.json`,
             JSON.stringify(fkAxeJson, null, 2),
         );
+
+        const result = await runCypressSpec("cypress/e2e/invalid-block.cy.ts");
+        expect(result.totalFailed).toBe(1);
+    });
+});
+
+describe("Configuration in cypress.config", () => {
+    it("should pass since we only check a valid block", async () => {
+        const fkAxeJson = {
+            context: {
+                include: [[".valid-block"]],
+            },
+        };
+
+        await generateCypressConfig(fkAxeJson);
+
+        const result = await runCypressSpec("cypress/e2e/invalid-block.cy.ts");
+        expect(result.totalFailed).toBe(0);
+    });
+
+    it("should fail since we check a invalid block", async () => {
+        const fkAxeJson = {
+            context: {
+                include: [[".invalid-block"]],
+            },
+        };
+
+        await generateCypressConfig(fkAxeJson);
 
         const result = await runCypressSpec("cypress/e2e/invalid-block.cy.ts");
         expect(result.totalFailed).toBe(1);


### PR DESCRIPTION
Tänker att vi på sikt kan bundla med konfiguration istället för att i varje app tillhandahålla en `fk-cypress-axe.json`, även om den featuren i sig kommer att finnas kvar ett tag.

Tagit genväg med typerna så du kan just nu passa in `any` vilket känns sådär..